### PR TITLE
Add concurency to build jobs execution

### DIFF
--- a/.github/workflows/build-android-podofo.yaml
+++ b/.github/workflows/build-android-podofo.yaml
@@ -39,6 +39,10 @@ on:
         required: true
         default: "1.2.13"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-android-brotli:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-ios-podofo.yaml
+++ b/.github/workflows/build-ios-podofo.yaml
@@ -34,6 +34,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-ios-freetype:


### PR DESCRIPTION
Running build jobs will get canceld when a new one is triggered